### PR TITLE
Remove filterBy method

### DIFF
--- a/lib/backbone-geojson/FeatureCollection.js
+++ b/lib/backbone-geojson/FeatureCollection.js
@@ -7,13 +7,6 @@ Backbone.GeoJson.FeatureCollection = Backbone.Collection.extend({
     return response.features;
   },
 
-  filterBy: function(where){
-    return new Backbone.GeoJson.FeatureCollection(this.filter(function(element){
-      var properties = _.pick(element.get('properties'), _.keys(where));
-      return _.isEqual(properties, where);
-    }));
-  },
-
   toGeoJSON: function(){
     var features = [];
     this.models.forEach(function(model){


### PR DESCRIPTION
Creo que este método no es necesario.

En este momento no está siendo llamado desde ningún sitio. Además el modelo de la colección ya se está diciendo que es un Feature, y el parse del feature convierte en atributos propios del modelo lo que venga en la clave 'properties' del json. Por lo que creo que este método es equivalente al `where` que implenta `Backbone.Collection`