### PR TITLE
Rename api

### DIFF
--- a/exploracao-new.js
+++ b/exploracao-new.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
 // var domains = DOMAINS_REPO;
 
 var domains = new Backbone.UILib.DomainCollection();
-domains.url = '/domains.json';
+domains.url = '/domains';
 
 domains.fetch({
   success: function(collection, response, options) {

--- a/exploracao-search.html
+++ b/exploracao-search.html
@@ -121,7 +121,7 @@
 
 <script type="text/template" id="exploracao-li-tmpl">
   <li class="row exploracao">
-    <a class="col-xs-12 pull-left" href="exploracao-show.html?exp_id=<%- exp_id %>"><%- exp_id %> <%- exp_name %></a>
+    <a class="col-xs-12 pull-left" href="exploracao-show.html?id=<%- id %>"><%- exp_id %> <%- exp_name %></a>
     <span class="col-xs-12 ">
       <small class="label label-success"><%- estado %></small>
       <small class="label label-default"><%- consumo %></small>

--- a/exploracao-search.js
+++ b/exploracao-search.js
@@ -9,7 +9,7 @@ var where = new Backbone.SIXHIARA.Where();
 var exploracaos = new Backbone.SIXHIARA.ExploracaoCollection();
 
 var domains = new Backbone.UILib.DomainCollection();
-domains.url = '/domains.json';
+domains.url = '/domains';
 
 domains.fetch({
   success: function(collection, response, options) {

--- a/exploracao-show.html
+++ b/exploracao-show.html
@@ -39,7 +39,7 @@
                 <button type="button" class="btn btn-default btn-sm">Documentos</button>
                 <button type="button" class="btn btn-primary btn-sm">Guardar</button>
                 <button type="button" class="btn btn-default btn-sm">Restaurar</button>
-                <button type="button" class="btn btn-default btn-sm">Eliminar</button>
+                <button id="delete-button" ftype="button" class="btn btn-default btn-sm">Eliminar</button>
               </span>
             </h3>
           </div>
@@ -460,6 +460,7 @@
 <script src="lib/backbone-uilib/views/WidgetsView.js"></script>
 <script src="views/TableRowShowView.js"></script>
 <script src="views/TableShowView.js"></script>
+<script src="views/ButtonDeleteView.js"></script>
 <script src="exploracao-show.js"></script>
 
 <script src="lib/leaflet/leaflet.js"></script>

--- a/exploracao-show.js
+++ b/exploracao-show.js
@@ -136,3 +136,8 @@ function populateFromFakeData(){
   }).render();
 
 }
+
+new Backbone.SIXHIARA.ButtonDeleteView({
+  el: $('#delete-button'),
+  model: exploracao
+});

--- a/models/Exploracao.js
+++ b/models/Exploracao.js
@@ -1,6 +1,8 @@
 Backbone.SIXHIARA = Backbone.SIXHIARA || {};
 Backbone.SIXHIARA.Exploracao = Backbone.GeoJson.Feature.extend({
 
+  rootUrl: '/exploracao',
+  
   defaults: {
     'exp_id':     '',
     'exp_name':   '',

--- a/models/Exploracao.js
+++ b/models/Exploracao.js
@@ -1,7 +1,7 @@
 Backbone.SIXHIARA = Backbone.SIXHIARA || {};
 Backbone.SIXHIARA.Exploracao = Backbone.GeoJson.Feature.extend({
 
-  rootUrl: '/exploracao',
+  urlRoot: '/exploracao',
   
   defaults: {
     'exp_id':     '',

--- a/models/ExploracaoCollection.js
+++ b/models/ExploracaoCollection.js
@@ -2,7 +2,7 @@ Backbone.SIXHIARA = Backbone.SIXHIARA || {};
 Backbone.SIXHIARA.ExploracaoCollection = Backbone.GeoJson.FeatureCollection.extend({
 
     model: Backbone.SIXHIARA.Exploracao,
-    url: '/exploracaos.json',
+    url: '/exploracaos',
 
     filterBy: function(where){
       a = this.filter(function(element) {

--- a/models/UtenteCollection.js
+++ b/models/UtenteCollection.js
@@ -2,6 +2,6 @@ Backbone.SIXHIARA = Backbone.SIXHIARA || {};
 Backbone.SIXHIARA.UtenteCollection = Backbone.Collection.extend({
 
     model: Backbone.SIXHIARA.Utente,
-    url: '/utentes.json'
+    url: '/utentes'
 
 });

--- a/views/ButtonDeleteView.js
+++ b/views/ButtonDeleteView.js
@@ -7,7 +7,6 @@ Backbone.SIXHIARA.ButtonDeleteView = Backbone.View.extend({
 
   doClick: function(){
     
-    this.model.url = '/exploracao/' + this.model.get('exp_id') + '.json';
     this.model.destroy({
       // wait: true,
       success: function(model, resp, options) {

--- a/views/ButtonDeleteView.js
+++ b/views/ButtonDeleteView.js
@@ -1,0 +1,23 @@
+Backbone.SIXHIARA = Backbone.SIXHIARA || {};
+Backbone.SIXHIARA.ButtonDeleteView = Backbone.View.extend({
+
+  events: {
+    "click": "doClick"
+  },
+
+  doClick: function(){
+    
+    this.model.url = '/exploracao/' + this.model.get('exp_id') + '.json';
+    this.model.destroy({
+      // wait: true,
+      success: function(model, resp, options) {
+        window.location = '/static/utentes-ui/exploracao-search.html';
+      },
+      error: function(xhr, textStatus, errorThrown) {
+        alert(textStatus.statusText);
+      }
+    });
+
+  }
+
+});

--- a/views/ButtonSaveView.js
+++ b/views/ButtonSaveView.js
@@ -23,15 +23,21 @@ Backbone.SIXHIARA.ButtonSaveView = Backbone.View.extend({
       if (! lics.at(0).get('lic_nro') ) lics.remove(lics.at(0));
     }
 
-
-    if(this.model.isValid()){
-      c = new Backbone.SIXHIARA.ExploracaoCollection();
-      c.create(this.model)
-      // make API configurable through config.js
-      window.location = 'http://localhost:6543/static/utentes-ui/exploracao-show.html?exp_id=' + this.model.get('exp_id');
-    } else {
-      alert(this.model.validationError);
+    if(! this.model.isValid()) {
+        alert(this.model.validationError);
+        return;
     }
+
+    this.model.save(null, {
+      wait: true,
+      success: function(model, resp, options) {
+        window.location = '/static/utentes-ui/exploracao-show.html?id=' + model.get('id');
+      },
+      error: function(xhr, textStatus, errorThrown) {
+        alert(textStatus.statusText);
+      }
+    });
+
   }
 
 });


### PR DESCRIPTION
Este pull request está relacionado con iCarto/utentes-api#1. Y tiene dos partes.

**Fijar el id de los modelos a la propiedad "id"**

Trabajando en la acción de borrar una explotación desde -show y leyendo el código de backbone veo un par de cosas interesantes. Los modelos individuales se pueden recuperar con fetch, actualizar/crear con save, y borrar con destroy. En el caso de save para saber si tiene que hacer POST o PUT y en el caso de destroy para saber si tiene que llamar a la API o le vale con destruirlo en cliente hacen uso del método isNew(), que básicamente comprueba si en el modelo una propiedad cuyo nombre por defecto es 'id' está seteada. Si está seteada asume que el modelo existe en la bd. Ese nombre por defecto se puede modificar fijando el valor de 'idAttribute'.

En nuestro caso el id, es el "gid" de la base de datos. Entre cambiar el idAttribute de todos los modelos y cambiar la API me pareció más lógico cambiar la api. De modo que ahora el json, en lugar de devolver "gid" devuelve "id".


**Renombrar la api**

Para evitar tener que meter mucho boilerplate con respecto a las url en los modelos creo que es mejor seguir el estándar de backbone al hacer rest. He modificado los endpoints de la api para que funcione así. (Ahora está mezclado /exploracaos y /exploracao pero esta sería la idea final)

GET /exploracaos Get all the exploracaos
POST /exploracaos Create a new exploracao
GET /exploracaos/{id} Get one exploracao
PUT /exploracaos/{id} Update one exploracao
DELETE /exploracaos/{id} Delete one exploracao

GET /utentes Get all the utentes

GET /domains Get all the domains


La contrapartida de este sistema es que las url ya no contendrías el exp_id si no el gid, por lo que pierden un poco de significado, pero teniendo en cuenta que en electron no se ven tampoco pasa nada.

**Prefijo para la api**

De hecho creo que sería conveniente usar un prefijo para la api tipo `/api/exploracaos`. Creo que así es limpio.